### PR TITLE
Teams integration: format and save llm response

### DIFF
--- a/caddy_chatbot/src/caddy_core/models.py
+++ b/caddy_chatbot/src/caddy_core/models.py
@@ -30,7 +30,7 @@ class UserMessage(pydantic.BaseModel):
 class LlmResponse(pydantic.BaseModel):
     response_id: str = str(uuid.uuid4())
     message_id: str
-    thread_id: str
+    thread_id: str | None = None
     llm_prompt: str
     llm_answer: str
     llm_response_json: Union[pydantic.Json, None] = None


### PR DESCRIPTION
Update teams implementation to format and save LlmResponses.
For now this follows the same saving convention as google chat (i.e. store usermessage and then storing llm response separately later). We should move to a single upload when we create the new table not keyed on thread_id