### PR TITLE
Reword Advisor Messages

### DIFF
--- a/caddy_chatbot/src/caddy_core/components.py
+++ b/caddy_chatbot/src/caddy_core/components.py
@@ -1,36 +1,33 @@
+import json
+import os
 from datetime import datetime
-from fastapi.responses import Response
-from fastapi import status
-
-from langchain.prompts import PromptTemplate
-from caddy_core.utils.prompt import retrieve_route_specific_augmentation, get_prompt
-
 from time import sleep
+from typing import Any, Dict, List, Tuple
 
+from boto3.dynamodb.conditions import Key
 from caddy_core.models import (
-    ProcessChatMessageEvent,
-    CaddyMessageEvent,
-    UserMessage,
-    LlmResponse,
-    SupervisionEvent,
     ApprovalEvent,
+    CaddyMessageEvent,
+    LlmResponse,
+    ProcessChatMessageEvent,
+    SupervisionEvent,
+    UserMessage,
 )
-
+from caddy_core.services import enrolment
+from caddy_core.services.evaluation import execute_optional_modules
+from caddy_core.services.retrieval_chain import build_chain
+from caddy_core.utils.monitoring import logger
+from caddy_core.utils.prompt import get_prompt, retrieve_route_specific_augmentation
 from caddy_core.utils.tables import (
     evaluation_table,
     responses_table,
     users_table,
 )
-from caddy_core.utils.monitoring import logger
-from caddy_core.services.retrieval_chain import build_chain
-from caddy_core.services import enrolment
-from caddy_core.services.evaluation import execute_optional_modules
-from boto3.dynamodb.conditions import Key
-
-import json
+from fastapi import status
+from fastapi.responses import Response
+from langchain.prompts import PromptTemplate
+from langchain_community.chat_models import BedrockChat
 from pytz import timezone
-
-from typing import List, Any, Dict, Tuple
 
 
 def rct_survey_reminder(event, user_record, chat_client):
@@ -371,6 +368,35 @@ def check_existing_call(caddy_message) -> Tuple[Dict[str, Any], bool]:
     return module_values, survey_complete
 
 
+def reword_advisor_message(message: str) -> str:
+    llm = BedrockChat(
+        model_id=os.getenv("LLM"),
+        region_name="eu-west-3",
+        model_kwargs={"temperature": 0.3, "top_k": 5, "max_tokens": 2000},
+    )
+    prompt = f"""You are an information extraction assistant called Caddy. 
+    Your task is to analyze the given message and extract key information that would be relevant 
+    for a legal assistance chatbot to perform a RAG (Retrieval-Augmented Generation) search. 
+    Follow these guidelines: 
+        1. Identify the main legal topic or issue being discussed. 
+        2. Extract any specific questions being asked. 
+        3. Note any relevant personal details of the individual involved (e.g., age, nationality, employment status). 
+        4. Identify key facts or circumstances related to the legal situation. 
+        5. Extract any mentioned dates, locations, or monetary amounts.
+        6. Identify any legal terms or concepts mentioned. 
+    Provide your response in a structured format with clear headings for each category of extracted information. 
+    If any category is not applicable or no relevant information is found skip it. 
+    Remember to focus only on extracting factual information without adding any interpretation or advice. 
+    
+    Input:
+    {message}
+    
+    Extracted Information:
+    """
+    response = llm.invoke(prompt)
+    return response.content
+
+
 def send_to_llm(caddy_query: UserMessage, chat_client):
     query = caddy_query.message
 
@@ -378,8 +404,7 @@ def send_to_llm(caddy_query: UserMessage, chat_client):
 
     chat_history = get_chat_history(caddy_query)
 
-    route_specific_augmentation, route = retrieve_route_specific_augmentation(
-        query)
+    route_specific_augmentation, route = retrieve_route_specific_augmentation(query)
 
     day_date_time = datetime.now(timezone("Europe/London")).strftime(
         "%A %d %B %Y %H:%M"
@@ -427,7 +452,7 @@ def send_to_llm(caddy_query: UserMessage, chat_client):
             accumulated_answer = ""
             for chunk in chain.stream(
                 {
-                    "input": query,
+                    "input": reword_advisor_message(query),
                     "chat_history": chat_history,
                 }
             ):
@@ -641,7 +666,7 @@ def temporary_teams_invoke(chat_client, caddy_message: CaddyMessageEvent):
 
     caddy_response = chain.invoke(
         {
-            "input": caddy_message.message_string,
+            "input": reword_advisor_message(caddy_message.message_string),
             "chat_history": [],
         }
     )


### PR DESCRIPTION
Small PR to reword advisor messages before using them for RAG. This was designed to address the problem Siobhan flagged where long messages including examples of things that haven't worked tend to produce poor outputs. 
This function produces rewordings that are pretty verbose and structured. We need to validate that it is actually solving the problem once Siobhan has sent over some real world examples.